### PR TITLE
feat(store): zustand 전역 상태 useBoardStore 생성 및 persist 적용 (localStorage 저장)

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,9 +1,36 @@
-//1. useBoardStore를 선언하여 zustand 스토어를 생성합니다.
-//2. persist 미들웨어를 사용하여 데이터를 localStorage에 저장합니다.
-//3. createJSONStorage를 사용하여 JSON 형식으로 데이터를 저장합니다.
-//4. set 함수를 사용하여 상태를 업데이트하는 메서드를 정의합니다.
-//5. addBoard, removeBoard, updateBoard 메서드를 사용하여 보드를 추가, 삭제 및 업데이트합니다.
-//6. data는 보드의 배열을 저장합니다. 초기값은 빈 배열 입니다. []
-//7. addBoard 메서드는 새로운 보드를 추가합니다.
-//8. removeBoard 메서드는 특정 ID를 가진 보드를 삭제합니다.
-//9. updateBoard 메서드는 특정 ID를 가진 보드를 업데이트합니다.
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+export const useBoardStore = create(
+  persist(
+    (set) => ({
+      // 보드의 배열 저장, 초기값은 빈 배열
+      data: [],
+
+      // Add
+      addBoard: (board) => {
+        set((state) => ({ data: [...state.data, board] }));
+      },
+
+      // Remove
+      removeBoard: (boardId) => {
+        set((state) => ({
+          data: state.data.filter((board) => board.id !== boardId),
+        }));
+      },
+
+      // Update
+      updateBoard: (update) => {
+        set((state) => ({
+          data: state.data.map((board) => (board.id === update.id ? { ...board, ...update } : board)),
+        }));
+      },
+    }),
+
+    // localStorage
+    {
+      name: 'board-storage', // localStorage의 key 값
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);


### PR DESCRIPTION
## Zustand로 전역 상태 관리하기

- Branch: refactor/zustand
- feat(store): zustand 전역 상태 useBoardStore 생성 및 persist 적용 (localStorage 저장)

<br>

## 🧩 Problem & Requirements
1. Zustand 전역 상태 생성하기
- store.js 파일 내에서 작성합니다.
* npm install zustand 를 터미널에 입력하여 설치합니다.
* useBoardStore 생성: Zustand의 create 함수를 사용하여 스토어를 정의합니다.
* **set**함수를 사용하여 상태를 업데이트 하는 메서드를 정의합니다.
    * 필요한 메서드 종류
        * addBoard : 보드를 추가하는 메서드 입니다.
        * removeBoard : item.id를 받아 보드를 삭제하는 메서드입니다.
        * updateBoard : item 을 받아 item.id가 같은 보드의 데이터를 수정하는 메서드입니다. map를 활용합니다.
* data : 보드의 배열을 저장합니다. 초기값은 빈 배열로 설정합니다. ****

2. persist 사용하기 (localStorage 저장)
* ❓ persist를 사용하지 않으면 어떤 문제가 발생하나요?
    * 페이지를 새로고침하면 상태가 초기화됩니다.
        * Zustand는 기본적으로 메모리 기반 상태 관리이기 때문에 새로고침 시 상태가 모두 사라집니다.
    * 사용자가 작성한 보드 데이터가 사라집니다.
        * 예를 들어, 새로 추가한 보드가 새로고침 한 번으로 모두 초기화될 수 있습니다.
    * 로컬 저장소에 데이터를 유지하지 못하므로 UX가 떨어집니다.
        * 사용자 입장에서는 작성한 내용이 저장되지 않아 신뢰도가 떨어질 수 있습니다.
* 따라서, persist 미들웨어를 사용하면 localStorage에 자동 저장되어 새로고침해도 데이터가 유지됩니다.
* persist : 미들웨어를 사용하여 데이터를**localStorage**에 자동으로 반영되도록 구현합니다.
* **createJSONStorage**를 사용하여 데이터를 **localStorage**에 저장합니다.

<br>

## 📌 Notes


<br>


## 🎯 학습 목표 및 복습할 개념 체크 리스트

1. [x] 전역 상태 라이브러리인 Zustand를 사용하여 전역 상태를 관리 해본다.
3. [x] 칸반 보드 프로젝트를 직접 구성해보면서 React와 더욱 친숙해지도록 학습한다.
 
<br>

## 📚 Reference (선택)

- [Zustand](https://zustand.docs.pmnd.rs/getting-started/introduction)

---

> 💡 이 브랜치는 학습용이며, 개인 레포 내에서만 관리됩니다.
> 원본 레포에는 PR을 보내지 않고, 개인 히스토리용으로 정리한 브랜치입니다.